### PR TITLE
feat: remote control using activepower on Solax Gen3 inverters 

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,11 +22,11 @@ This file helps AI coding agents work safely and efficiently in this repository.
 - SolaX plugin entities and callbacks: [custom_components/solax_modbus/plugin_solax.py](custom_components/solax_modbus/plugin_solax.py)
 
 ## Export Control Logic (Focus: export_duration)
-- `export_duration` is a select entity in [custom_components/solax_modbus/plugin_solax.py](custom_components/solax_modbus/plugin_solax.py#L2907):
+- `export_duration` is a select entity in [custom_components/solax_modbus/plugin_solax.py](custom_components/solax_modbus/plugin_solax.py):
   - key: `export_duration`
   - write register: `0x9F`
   - options map: seconds -> labels (`4`, `900`, `1800`, `2700`, `3600`, `5400`, `7200`)
-- Feedback is read via a sensor with the same key in [custom_components/solax_modbus/plugin_solax.py](custom_components/solax_modbus/plugin_solax.py#L4627):
+- Feedback is read via a sensor with the same key in [custom_components/solax_modbus/plugin_solax.py](custom_components/solax_modbus/plugin_solax.py):
   - read register: `0x10B`
   - `scale` dict mirrors the select option dict.
 - Write path:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,63 @@
+# AGENTS.md
+
+## Purpose
+This file helps AI coding agents work safely and efficiently in this repository.
+
+## Quick Start
+- Python: 3.12+
+- Install/sync deps: `uv sync --all-groups`
+- Lint/format checks: `uv run pre-commit run --all-files`
+- Type checks: `uv run mypy custom_components/solax_modbus tests --strict`
+- Tests (fast): `uv run pytest -m "not slow"`
+- Tests (full): `uv run pytest`
+- Convenience script: `./scripts/test.zsh [--full|--cov]`
+
+## Code Map
+- Integration hub and modbus I/O: [custom_components/solax_modbus/__init__.py](custom_components/solax_modbus/__init__.py)
+- Entity platform loaders:
+  - [custom_components/solax_modbus/number.py](custom_components/solax_modbus/number.py)
+  - [custom_components/solax_modbus/select.py](custom_components/solax_modbus/select.py)
+  - [custom_components/solax_modbus/sensor.py](custom_components/solax_modbus/sensor.py)
+- Plugin architecture and entity description types: [custom_components/solax_modbus/const.py](custom_components/solax_modbus/const.py)
+- SolaX plugin entities and callbacks: [custom_components/solax_modbus/plugin_solax.py](custom_components/solax_modbus/plugin_solax.py)
+
+## Export Control Logic (Focus: export_duration)
+- `export_duration` is a select entity in [custom_components/solax_modbus/plugin_solax.py](custom_components/solax_modbus/plugin_solax.py#L2907):
+  - key: `export_duration`
+  - write register: `0x9F`
+  - options map: seconds -> labels (`4`, `900`, `1800`, `2700`, `3600`, `5400`, `7200`)
+- Feedback is read via a sensor with the same key in [custom_components/solax_modbus/plugin_solax.py](custom_components/solax_modbus/plugin_solax.py#L4627):
+  - read register: `0x10B`
+  - `scale` dict mirrors the select option dict.
+- Write path:
+  - `async_select_option` reverse-maps label -> integer and writes via hub in [custom_components/solax_modbus/select.py](custom_components/solax_modbus/select.py#L147)
+  - low-level conversion/write occurs in [custom_components/solax_modbus/__init__.py](custom_components/solax_modbus/__init__.py#L1202)
+
+## Critical Guardrails for export_duration Changes
+- Keep the select `option_dict` and sensor `scale` mapping in sync.
+- Do not confuse export-duration with remote-control duration:
+  - `export_duration` is separate from `remotecontrol_duration` and `remotecontrol_autorepeat_duration`.
+  - See [docs/solax-mode1-modbus-power-control.md](docs/solax-mode1-modbus-power-control.md).
+- Keep register roles distinct:
+  - command write register: `0x9F`
+  - feedback read register: `0x10B`
+- Be cautious with automation advice for export-control settings: writable export parameters are generally EEPROM-backed on SolaX and should not be churned frequently.
+  - See warning in [docs/solax-G4-operation-modes.md](docs/solax-G4-operation-modes.md).
+- Parallel-mode limit adjustments in `localDataCallback` target export limits and remote control limits, not `export_duration`.
+
+## Editing Conventions
+- Prefer plugin-level entity descriptions for behavior changes; avoid ad-hoc logic in platform modules unless needed.
+- For select entities, keep `option_dict` values unique so reverse mapping remains deterministic.
+- Keep changes narrowly scoped by inverter family and `allowedtypes` masks.
+
+## Validation Checklist for export_duration PRs
+- Confirm UI option list, register write (`0x9F`), and sensor feedback (`0x10B`) all agree.
+- Run: `uv run mypy custom_components/solax_modbus tests --strict`
+- Run: `uv run pytest -m "not slow"`
+- If touching shared entity plumbing (`select.py`/hub write path), run full tests: `uv run pytest`
+
+## Key Docs (Link, do not duplicate)
+- Developer internals: [docs/developer_guide.md](docs/developer_guide.md)
+- CI/CD checks and local equivalents: [docs/developer/cicd-pipeline.md](docs/developer/cicd-pipeline.md)
+- SolaX operation modes + EEPROM caution: [docs/solax-G4-operation-modes.md](docs/solax-G4-operation-modes.md)
+- Mode 1 remote control duration semantics: [docs/solax-mode1-modbus-power-control.md](docs/solax-mode1-modbus-power-control.md)

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -598,9 +598,9 @@ def autorepeat_function_remotecontrol_recompute_gen3(initval: int, descr: Any, d
         return {"action": WRITE_MULTI_MODBUS, "data": []}
 
     res: list[tuple[Any, Any]] = [
-        (REGISTER_U16, 1),         # 0x7C: control enable
+        (REGISTER_U16, 1),  # 0x7C: control enable
         (REGISTER_S32, ap_target),  # 0x7D–0x7E: active power, LSW-first via order32=little
-        (REGISTER_S32, 0),          # 0x7F–0x80: reactive power (always 0 for Gen3)
+        (REGISTER_S32, 0),  # 0x7F–0x80: reactive power (always 0 for Gen3)
     ]
 
     if power_control == "Disabled":

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -550,7 +550,7 @@ def autorepeat_function_remotecontrol_recompute(initval: int, descr: Any, datadi
         ("remotecontrol_set_type", params["set_type"]),
         ("remotecontrol_active_power", params["ap_target"]),
         ("remotecontrol_reactive_power", params["reactive_power"]),
-        ("remotecontrol_duration", datadict.get("remotecontrol_duration", 20)),
+        ("remotecontrol_duration", params["rc_duration"]),
         (REGISTER_U16, 0),  # dummy target soc
         (REGISTER_U32, 0),  # dummy target energy Wh
         (REGISTER_S32, 0),  # dummy target charge/discharge power

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -245,27 +245,20 @@ class SolaXModbusSwitchEntityDescription(BaseModbusSwitchEntityDescription):
 # ====================================== Computed value functions  =================================================
 
 
-def autorepeat_function_remotecontrol_recompute(initval: int, descr: Any, datadict: dict[str, Any]) -> dict[str, Any]:
-    """Remote control power calculations for SolaX inverters - Redesigned Implementation.
+def _compute_remotecontrol_ap_target(datadict: dict[str, Any]) -> dict[str, Any]:
+    """Shared computation of the clamped active-power target for remotecontrol modes 1-7.
 
-    This function implements the redesigned remote control calculations based on clear
-    variable names and logical formulas. For detailed documentation, see:
-    docs/solax-remote-control-redesigned.md
+    Reads control parameters, power measurements and phase data from *datadict*,
+    applies mode-specific logic, phase-envelope protection and import/export bounds,
+    and returns a dict with the final clamped values:
 
-    Args:
-        initval: BUTTONREPEAT_FIRST (first run), BUTTONREPEAT_LOOP (subsequent runs),
-                or BUTTONREPEAT_POST (cleanup)
-        descr: Entity description
-        datadict: Current sensor data dictionary
-
-    Returns:
-        Dictionary with action and data for Modbus write operations
+        power_control  – final mode string (may be normalised to "Enabled Power Control")
+        set_type       – "Set" or "Update"
+        ap_target      – clamped active power target in Watts (int)
+        reactive_power – clamped reactive power in VAr (int)
+        rc_duration    – command duration in seconds
+        rc_timeout     – autorepeat timeout in seconds
     """
-
-    # terminate expiring loop by disabling remotecontrol
-    if initval == BUTTONREPEAT_POST:
-        return {"action": WRITE_MULTI_MODBUS, "data": [("remotecontrol_power_control", "Disabled")]}
-
     # Get control parameters
     power_control = datadict.get("remotecontrol_power_control", "Disabled")
     set_type = datadict.get("remotecontrol_set_type", "Set")
@@ -300,7 +293,14 @@ def autorepeat_function_remotecontrol_recompute(initval: int, descr: Any, datadi
     elif parallel_setting == "Slave":
         # Slaves should not execute remote control
         _LOGGER.debug("[REMOTE_CONTROL] Parallel mode detected (Slave): skipping remote control")
-        return {"action": WRITE_MULTI_MODBUS, "data": []}
+        return {
+            "power_control": "Disabled",
+            "set_type": set_type,
+            "ap_target": 0,
+            "reactive_power": 0,
+            "rc_duration": rc_duration,
+            "rc_timeout": rc_timeout,
+        }
     else:
         # Single inverter mode - use individual values
         pv_power = datadict.get("pv_power_total", 0)
@@ -365,6 +365,9 @@ def autorepeat_function_remotecontrol_recompute(initval: int, descr: Any, datadi
             power_control = "Disabled"
 
     elif power_control == "Disabled":
+        ap_target = target
+
+    else:
         ap_target = target
 
     # Debug logging: Target calculation
@@ -504,23 +507,106 @@ def autorepeat_function_remotecontrol_recompute(initval: int, descr: Any, datadi
             f"adjusted_by={old_ap_target - ap_target}W"
         )
 
-    # Prepare result data
+    return {
+        "power_control": power_control,
+        "set_type": set_type,
+        "ap_target": int(ap_target),
+        "reactive_power": int(max(min(reap_up, reactive_power), reap_lo)),
+        "rc_duration": rc_duration,
+        "rc_timeout": rc_timeout,
+    }
+
+
+def autorepeat_function_remotecontrol_recompute(initval: int, descr: Any, datadict: dict[str, Any]) -> dict[str, Any]:
+    """Remote control power calculations for SolaX inverters - Redesigned Implementation.
+
+    This function implements the redesigned remote control calculations based on clear
+    variable names and logical formulas. For detailed documentation, see:
+    docs/solax-remote-control-redesigned.md
+
+    Args:
+        initval: BUTTONREPEAT_FIRST (first run), BUTTONREPEAT_LOOP (subsequent runs),
+                or BUTTONREPEAT_POST (cleanup)
+        descr: Entity description
+        datadict: Current sensor data dictionary
+
+    Returns:
+        Dictionary with action and data for Modbus write operations
+    """
+
+    # terminate expiring loop by disabling remotecontrol
+    if initval == BUTTONREPEAT_POST:
+        return {"action": WRITE_MULTI_MODBUS, "data": [("remotecontrol_power_control", "Disabled")]}
+
+    params = _compute_remotecontrol_ap_target(datadict)
+    power_control = params["power_control"]
+
+    # For Slave parallel mode, _compute returns Disabled with empty ap_target — bail out silently
+    if power_control == "Disabled" and datadict.get("parallel_setting") == "Slave":
+        return {"action": WRITE_MULTI_MODBUS, "data": []}
+
     res = [
         ("remotecontrol_power_control", power_control),
-        ("remotecontrol_set_type", set_type),
-        ("remotecontrol_active_power", ap_target),
-        ("remotecontrol_reactive_power", max(min(reap_up, reactive_power), reap_lo)),
-        ("remotecontrol_duration", rc_duration),
+        ("remotecontrol_set_type", params["set_type"]),
+        ("remotecontrol_active_power", params["ap_target"]),
+        ("remotecontrol_reactive_power", params["reactive_power"]),
+        ("remotecontrol_duration", datadict.get("remotecontrol_duration", 20)),
         (REGISTER_U16, 0),  # dummy target soc
         (REGISTER_U32, 0),  # dummy target energy Wh
         (REGISTER_S32, 0),  # dummy target charge/discharge power
-        ("remotecontrol_timeout", rc_timeout),
+        ("remotecontrol_timeout", params["rc_timeout"]),
     ]
 
     if power_control == "Disabled":
         autorepeat_stop(datadict, "remotecontrol_trigger")
 
     _LOGGER.debug(f"Evaluated remotecontrol_trigger: corrected/clamped values: {res}")
+    return {"action": WRITE_MULTI_MODBUS, "data": res}
+
+
+def autorepeat_function_remotecontrol_recompute_gen3(initval: int, descr: Any, datadict: dict[str, Any]) -> dict[str, Any]:
+    """Active power control for SolaX X1 AC G3 inverters.
+
+    Sends a 5-register FC16 burst starting at 0x7C:
+      0x7C        U16  – control enable (1 = active, 0 = disabled)
+      0x7D–0x7E   S32  – active power in Watts, LSW-first (order32=little)
+                         negative = export/discharge, positive = import/charge
+      0x7F–0x80   S32  – reactive power (always 0)
+
+    The inverter reverts to self-consumption if no refresh arrives within 4 s
+    (configured via register 0x9F = 4 at startup).  Set
+    *remotecontrol_autorepeat_duration* to the desired window (seconds) and
+    the integration will keep sending commands every poll cycle.
+    """
+    if initval == BUTTONREPEAT_POST:
+        # Zero all five registers to relinquish control
+        return {
+            "action": WRITE_MULTI_MODBUS,
+            "data": [
+                (REGISTER_U16, 0),  # 0x7C: disable control
+                (REGISTER_S32, 0),  # 0x7D–0x7E: active power = 0
+                (REGISTER_S32, 0),  # 0x7F–0x80: reactive power = 0
+            ],
+        }
+
+    params = _compute_remotecontrol_ap_target(datadict)
+    power_control = params["power_control"]
+    ap_target = params["ap_target"]
+
+    # For Slave parallel mode, bail out silently
+    if power_control == "Disabled" and datadict.get("parallel_setting") == "Slave":
+        return {"action": WRITE_MULTI_MODBUS, "data": []}
+
+    res: list[tuple[Any, Any]] = [
+        (REGISTER_U16, 1),         # 0x7C: control enable
+        (REGISTER_S32, ap_target),  # 0x7D–0x7E: active power, LSW-first via order32=little
+        (REGISTER_S32, 0),          # 0x7F–0x80: reactive power (always 0 for Gen3)
+    ]
+
+    if power_control == "Disabled":
+        autorepeat_stop(datadict, "remotecontrol_trigger_gen3")
+
+    _LOGGER.debug(f"Evaluated remotecontrol_trigger_gen3: power_control={power_control} ap_target={ap_target}W payload: {res}")
     return {"action": WRITE_MULTI_MODBUS, "data": res}
 
 
@@ -1158,6 +1244,16 @@ BUTTON_TYPES: Sequence["SolaxModbusButtonEntityDescription"] = [
         autorepeat="remotecontrol_autorepeat_duration",
     ),
     SolaxModbusButtonEntityDescription(
+        name="Remotecontrol Trigger Gen3 (mode 1-7)",
+        key="remotecontrol_trigger_gen3",
+        register=0x7C,
+        allowedtypes=AC | GEN3 | X1,
+        write_method=WRITE_MULTI_MODBUS,
+        icon="mdi:battery-clock",
+        value_function=autorepeat_function_remotecontrol_recompute_gen3,
+        autorepeat="remotecontrol_autorepeat_duration",
+    ),
+    SolaxModbusButtonEntityDescription(
         name="PowerControlMode Trigger (mode 8/9)",
         key="powercontrolmode8_trigger",
         register=0xA0,
@@ -1418,7 +1514,7 @@ NUMBER_TYPES: Sequence["SolaxModbusNumberEntityDescription"] = [
     SolaxModbusNumberEntityDescription(
         name="Remotecontrol Active Power (mode 1)",
         key="remotecontrol_active_power",
-        allowedtypes=AC | HYBRID | GEN4 | GEN5,
+        allowedtypes=AC | HYBRID | GEN3 | GEN4 | GEN5,
         native_min_value=-30000,
         native_max_value=30000,
         native_step=100,
@@ -1465,7 +1561,7 @@ NUMBER_TYPES: Sequence["SolaxModbusNumberEntityDescription"] = [
         name="Remotecontrol Autorepeat Duration (mode 1-9)",
         key="remotecontrol_autorepeat_duration",
         register_data_type=REGISTER_U16,
-        allowedtypes=AC | HYBRID | GEN4 | GEN5 | GEN6,
+        allowedtypes=AC | HYBRID | GEN3 | GEN4 | GEN5 | GEN6,
         icon="mdi:home-clock",
         initvalue=0,  # seconds -
         native_min_value=0,
@@ -1479,7 +1575,7 @@ NUMBER_TYPES: Sequence["SolaxModbusNumberEntityDescription"] = [
     SolaxModbusNumberEntityDescription(
         name="Remotecontrol Import Limit (mode 1-9)",
         key="remotecontrol_import_limit",
-        allowedtypes=AC | HYBRID | GEN4 | GEN5 | GEN6,
+        allowedtypes=AC | HYBRID | GEN3 | GEN4 | GEN5 | GEN6,
         native_min_value=0,
         native_max_value=30000,  # overwritten by MAX_EXPORT
         native_step=100,
@@ -1552,7 +1648,7 @@ NUMBER_TYPES: Sequence["SolaxModbusNumberEntityDescription"] = [
     SolaxModbusNumberEntityDescription(
         name="Remotecontrol Timeout (mode 1-9)",
         key="remotecontrol_timeout",
-        allowedtypes=AC | HYBRID | GEN4 | GEN5 | GEN6,
+        allowedtypes=AC | HYBRID | GEN3 | GEN4 | GEN5 | GEN6,
         native_min_value=0,
         native_max_value=28800,
         native_step=1,
@@ -2508,7 +2604,7 @@ SELECT_TYPES: Sequence["SolaxModbusSelectEntityDescription"] = [
             # 2: "Enabled Quantity Control",
             # 3: "Enabled SOC Target Control",
         },
-        allowedtypes=AC | HYBRID | GEN4 | GEN5,
+        allowedtypes=AC | HYBRID | GEN3 | GEN4 | GEN5,
         initvalue=0,  # Disabled
         icon="mdi:transmission-tower",
     ),

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -573,10 +573,10 @@ def autorepeat_function_remotecontrol_recompute_gen3(initval: int, descr: Any, d
                          negative = export/discharge, positive = import/charge
       0x7F–0x80   S32  – reactive power (always 0)
 
-    The inverter reverts to self-consumption if no refresh arrives within 4 s
-    (configured via register 0x9F = 4 at startup).  Set
-    *remotecontrol_autorepeat_duration* to the desired window (seconds) and
-    the integration will keep sending commands every poll cycle.
+    The inverter reverts to self-consumption if no refresh arrives within
+    4 s. Set *remotecontrol_autorepeat_duration* to the desired
+    window (seconds) and the integration will keep sending commands every
+    poll cycle while the remote-control override is active.
     """
     if initval == BUTTONREPEAT_POST:
         # Zero all five registers to relinquish control
@@ -605,6 +605,13 @@ def autorepeat_function_remotecontrol_recompute_gen3(initval: int, descr: Any, d
 
     if power_control == "Disabled":
         autorepeat_stop(datadict, "remotecontrol_trigger_gen3")
+        # Emit disable frame immediately. autorepeat_stop() sets _repeatUntil to 0,
+        # so no BUTTONREPEAT_POST cleanup frame will be sent by the scheduler.
+        res = [
+            (REGISTER_U16, 0),
+            (REGISTER_S32, 0),
+            (REGISTER_S32, 0),
+        ]
 
     _LOGGER.debug(f"Evaluated remotecontrol_trigger_gen3: power_control={power_control} ap_target={ap_target}W payload: {res}")
     return {"action": WRITE_MULTI_MODBUS, "data": res}

--- a/tests/unit/test_plugin_logic.py
+++ b/tests/unit/test_plugin_logic.py
@@ -4,11 +4,17 @@ import pytest
 
 from custom_components.solax_modbus.plugin_solax import (
     AC,
+    BUTTONREPEAT_FIRST,
+    BUTTONREPEAT_POST,
     EPS,
     GEN3,
     GEN4,
     HYBRID,
+    REGISTER_S32,
+    REGISTER_U16,
+    WRITE_MULTI_MODBUS,
     X3,
+    autorepeat_function_remotecontrol_recompute_gen3,
 )
 from custom_components.solax_modbus.plugin_solax import (
     plugin_instance as solax_plugin,
@@ -148,3 +154,59 @@ def test_parallel_master_scales_import_limit(mock_hub: Any) -> None:
     assert entity._attr_native_max_value == 45000, (
         f"Parallel Master with 45kW capacity should scale import limit to 45000W, got {entity._attr_native_max_value}W"
     )
+
+
+def test_remotecontrol_gen3_payload_shape_enabled() -> None:
+    datadict = {
+        "remotecontrol_power_control": "Enabled Power Control",
+        "remotecontrol_active_power": -1000,
+        "remotecontrol_reactive_power": 0,
+        "remotecontrol_duration": 20,
+        "remotecontrol_timeout": 0,
+        "remotecontrol_import_limit": 20000,
+        "export_control_user_limit": 20000,
+    }
+
+    payload = autorepeat_function_remotecontrol_recompute_gen3(BUTTONREPEAT_FIRST, None, datadict)
+
+    assert payload["action"] == WRITE_MULTI_MODBUS
+    assert payload["data"] == [
+        (REGISTER_U16, 1),
+        (REGISTER_S32, -1000),
+        (REGISTER_S32, 0),
+    ]
+
+
+def test_remotecontrol_gen3_payload_shape_post_cleanup() -> None:
+    payload = autorepeat_function_remotecontrol_recompute_gen3(BUTTONREPEAT_POST, None, {})
+
+    assert payload["action"] == WRITE_MULTI_MODBUS
+    assert payload["data"] == [
+        (REGISTER_U16, 0),
+        (REGISTER_S32, 0),
+        (REGISTER_S32, 0),
+    ]
+
+
+def test_remotecontrol_gen3_disabled_calls_autorepeat_stop(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[dict[str, Any], str]] = []
+
+    def fake_autorepeat_stop(data: dict[str, Any], key: str) -> None:
+        calls.append((data, key))
+
+    monkeypatch.setattr("custom_components.solax_modbus.plugin_solax.autorepeat_stop", fake_autorepeat_stop)
+
+    datadict: dict[str, Any] = {
+        "remotecontrol_power_control": "Disabled",
+        "remotecontrol_active_power": 0,
+    }
+
+    payload = autorepeat_function_remotecontrol_recompute_gen3(BUTTONREPEAT_FIRST, None, datadict)
+
+    assert payload["action"] == WRITE_MULTI_MODBUS
+    assert payload["data"] == [
+        (REGISTER_U16, 0),
+        (REGISTER_S32, 0),
+        (REGISTER_S32, 0),
+    ]
+    assert calls == [(datadict, "remotecontrol_trigger_gen3")]

--- a/tests/unit/test_plugin_logic.py
+++ b/tests/unit/test_plugin_logic.py
@@ -2,17 +2,19 @@ from typing import Any
 
 import pytest
 
-from custom_components.solax_modbus.plugin_solax import (
-    AC,
+from custom_components.solax_modbus.const import (
     BUTTONREPEAT_FIRST,
     BUTTONREPEAT_POST,
+    REGISTER_S32,
+    REGISTER_U16,
+    WRITE_MULTI_MODBUS,
+)
+from custom_components.solax_modbus.plugin_solax import (
+    AC,
     EPS,
     GEN3,
     GEN4,
     HYBRID,
-    REGISTER_S32,
-    REGISTER_U16,
-    WRITE_MULTI_MODBUS,
     X3,
     autorepeat_function_remotecontrol_recompute_gen3,
 )


### PR DESCRIPTION
**plugin_solax.py refactoring**
- Extracted _compute_remotecontrol_ap_target(datadict) — a shared helper containing all the ap_target calculation logic (mode dispatch, phase-envelope protection, import/export bounds). Returns a dict with power_control, ap_target, reactive_power, set_type, rc_duration, rc_timeout.
- autorepeat_function_remotecontrol_recompute (Gen4/5) now delegates to this helper and just assembles the original Gen4/5 payload.

**New Gen3 support**
autorepeat_function_remotecontrol_recompute_gen3 — same control logic via the shared helper, but produces a Gen3 compatible payload:

- remotecontrol_power_control (select) — the mode chooser
- remotecontrol_active_power (number) — the watt target
- remotecontrol_import_limit (number) — caps grid import
- remotecontrol_autorepeat_duration (number) — how long to keep sending
- remotecontrol_timeout (number) — watchdog for command expiry