### PR TITLE
Gen3 X1 AC remote-control: dumb-pipe rewrite, dedicated keepalive, atomic multi-register write

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,11 +22,11 @@ This file helps AI coding agents work safely and efficiently in this repository.
 - SolaX plugin entities and callbacks: [custom_components/solax_modbus/plugin_solax.py](custom_components/solax_modbus/plugin_solax.py)
 
 ## Export Control Logic (Focus: export_duration)
-- `export_duration` is a select entity in [custom_components/solax_modbus/plugin_solax.py](custom_components/solax_modbus/plugin_solax.py#L2907):
+- `export_duration` is a select entity in [custom_components/solax_modbus/plugin_solax.py](custom_components/solax_modbus/plugin_solax.py):
   - key: `export_duration`
   - write register: `0x9F`
   - options map: seconds -> labels (`4`, `900`, `1800`, `2700`, `3600`, `5400`, `7200`)
-- Feedback is read via a sensor with the same key in [custom_components/solax_modbus/plugin_solax.py](custom_components/solax_modbus/plugin_solax.py#L4627):
+- Feedback is read via a sensor with the same key in [custom_components/solax_modbus/plugin_solax.py](custom_components/solax_modbus/plugin_solax.py):
   - read register: `0x10B`
   - `scale` dict mirrors the select option dict.
 - Write path:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,63 @@
+# AGENTS.md
+
+## Purpose
+This file helps AI coding agents work safely and efficiently in this repository.
+
+## Quick Start
+- Python: 3.12+
+- Install/sync deps: `uv sync --all-groups`
+- Lint/format checks: `uv run pre-commit run --all-files`
+- Type checks: `uv run mypy custom_components/solax_modbus tests --strict`
+- Tests (fast): `uv run pytest -m "not slow"`
+- Tests (full): `uv run pytest`
+- Convenience script: `./scripts/test.zsh [--full|--cov]`
+
+## Code Map
+- Integration hub and modbus I/O: [custom_components/solax_modbus/__init__.py](custom_components/solax_modbus/__init__.py)
+- Entity platform loaders:
+  - [custom_components/solax_modbus/number.py](custom_components/solax_modbus/number.py)
+  - [custom_components/solax_modbus/select.py](custom_components/solax_modbus/select.py)
+  - [custom_components/solax_modbus/sensor.py](custom_components/solax_modbus/sensor.py)
+- Plugin architecture and entity description types: [custom_components/solax_modbus/const.py](custom_components/solax_modbus/const.py)
+- SolaX plugin entities and callbacks: [custom_components/solax_modbus/plugin_solax.py](custom_components/solax_modbus/plugin_solax.py)
+
+## Export Control Logic (Focus: export_duration)
+- `export_duration` is a select entity in [custom_components/solax_modbus/plugin_solax.py](custom_components/solax_modbus/plugin_solax.py#L2907):
+  - key: `export_duration`
+  - write register: `0x9F`
+  - options map: seconds -> labels (`4`, `900`, `1800`, `2700`, `3600`, `5400`, `7200`)
+- Feedback is read via a sensor with the same key in [custom_components/solax_modbus/plugin_solax.py](custom_components/solax_modbus/plugin_solax.py#L4627):
+  - read register: `0x10B`
+  - `scale` dict mirrors the select option dict.
+- Write path:
+  - `async_select_option` reverse-maps label -> integer and writes via hub in [custom_components/solax_modbus/select.py](custom_components/solax_modbus/select.py#L147)
+  - low-level conversion/write occurs in [custom_components/solax_modbus/__init__.py](custom_components/solax_modbus/__init__.py#L1202)
+
+## Critical Guardrails for export_duration Changes
+- Keep the select `option_dict` and sensor `scale` mapping in sync.
+- Do not confuse export-duration with remote-control duration:
+  - `export_duration` is separate from `remotecontrol_duration` and `remotecontrol_autorepeat_duration`.
+  - See [docs/solax-mode1-modbus-power-control.md](docs/solax-mode1-modbus-power-control.md).
+- Keep register roles distinct:
+  - command write register: `0x9F`
+  - feedback read register: `0x10B`
+- Be cautious with automation advice for export-control settings: writable export parameters are generally EEPROM-backed on SolaX and should not be churned frequently.
+  - See warning in [docs/solax-G4-operation-modes.md](docs/solax-G4-operation-modes.md).
+- Parallel-mode limit adjustments in `localDataCallback` target export limits and remote control limits, not `export_duration`.
+
+## Editing Conventions
+- Prefer plugin-level entity descriptions for behavior changes; avoid ad-hoc logic in platform modules unless needed.
+- For select entities, keep `option_dict` values unique so reverse mapping remains deterministic.
+- Keep changes narrowly scoped by inverter family and `allowedtypes` masks.
+
+## Validation Checklist for export_duration PRs
+- Confirm UI option list, register write (`0x9F`), and sensor feedback (`0x10B`) all agree.
+- Run: `uv run mypy custom_components/solax_modbus tests --strict`
+- Run: `uv run pytest -m "not slow"`
+- If touching shared entity plumbing (`select.py`/hub write path), run full tests: `uv run pytest`
+
+## Key Docs (Link, do not duplicate)
+- Developer internals: [docs/developer_guide.md](docs/developer_guide.md)
+- CI/CD checks and local equivalents: [docs/developer/cicd-pipeline.md](docs/developer/cicd-pipeline.md)
+- SolaX operation modes + EEPROM caution: [docs/solax-G4-operation-modes.md](docs/solax-G4-operation-modes.md)
+- Mode 1 remote control duration semantics: [docs/solax-mode1-modbus-power-control.md](docs/solax-mode1-modbus-power-control.md)

--- a/custom_components/solax_modbus/__init__.py
+++ b/custom_components/solax_modbus/__init__.py
@@ -1331,7 +1331,19 @@ class SolaXModbusHub:
             ) in payload:
                 if key.startswith("_"):
                     typ = key
-                    value = int(value)
+                    try:
+                        value = int(value)
+                    except Exception as ex:
+                        # Abort the whole write rather than proceeding with a shorter,
+                        # misaligned regs_out: this payload is meant to land as one
+                        # atomic multi-register burst (e.g. the Gen3 remote-control
+                        # command), and writing fewer registers than intended shifts
+                        # every value after this one to the wrong offset on the wire.
+                        _LOGGER.error(
+                            f"{self._name}: could not cast '{value}' to int for register type {typ}; "
+                            f"aborting entire write payload:{payload} with exception {ex}"
+                        )
+                        return None
                 else:
                     descr = self.writeLocals[key]
                     # --- Begin safer reverse_option_dict mapping logic ---
@@ -1364,19 +1376,26 @@ class SolaXModbusHub:
                     typ = descr.register_data_type
                 try:
                     if typ == REGISTER_U16:
-                        regs_out += convert_to_registers(value, DataType.UINT16, self.plugin.order32)  # type: ignore[attr-defined]
+                        encoded = convert_to_registers(value, DataType.UINT16, self.plugin.order32)  # type: ignore[attr-defined]
                     elif typ == REGISTER_S16:
-                        regs_out += convert_to_registers(value, DataType.INT16, self.plugin.order32)  # type: ignore[attr-defined]
+                        encoded = convert_to_registers(value, DataType.INT16, self.plugin.order32)  # type: ignore[attr-defined]
                     elif typ == REGISTER_U32:
-                        regs_out += convert_to_registers(value, DataType.UINT32, self.plugin.order32)  # type: ignore[attr-defined]
+                        encoded = convert_to_registers(value, DataType.UINT32, self.plugin.order32)  # type: ignore[attr-defined]
                     elif typ == REGISTER_F32:
-                        regs_out += convert_to_registers(value, DataType.FLOAT32, self.plugin.order32)  # type: ignore[attr-defined]
+                        encoded = convert_to_registers(value, DataType.FLOAT32, self.plugin.order32)  # type: ignore[attr-defined]
                     elif typ == REGISTER_S32:
-                        regs_out += convert_to_registers(value, DataType.INT32, self.plugin.order32)  # type: ignore[attr-defined]
+                        encoded = convert_to_registers(value, DataType.INT32, self.plugin.order32)  # type: ignore[attr-defined]
                     else:
-                        _LOGGER.error(f"unsupported unit type: {typ} for {key}")
+                        _LOGGER.error(f"{self._name}: unsupported register type: {typ} for {key}; aborting entire write payload:{payload}")
+                        return None
                 except Exception as ex:
-                    _LOGGER.error(f"{self._name}: conversion for typ={typ} value={value} failed payload:{payload} with exception {ex}")
+                    # Abort the whole write rather than proceeding with a shorter,
+                    # misaligned regs_out (see the "_"-prefixed-key branch above for why).
+                    _LOGGER.error(
+                        f"{self._name}: conversion for typ={typ} value={value} failed; aborting entire write payload:{payload} with exception {ex}"
+                    )
+                    return None
+                regs_out += encoded
             online = await self.is_online()
             _LOGGER.debug(f"Ready to write multiple registers at 0x{address:02x}: {regs_out} online: {online} ")
             if online:

--- a/custom_components/solax_modbus/button.py
+++ b/custom_components/solax_modbus/button.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Callable
 from dataclasses import replace
 from datetime import timedelta
 from time import time
@@ -112,7 +113,7 @@ class SolaXModbusButton(ButtonEntity):
         self._command = button_info.command
         self._attr_icon = button_info.icon
         self._write_method = button_info.write_method
-        self._gen3_keepalive_unsub = None
+        self._gen3_keepalive_unsub: Callable[[], None] | None = None
 
     @property
     def name(self) -> str:

--- a/custom_components/solax_modbus/button.py
+++ b/custom_components/solax_modbus/button.py
@@ -1,5 +1,6 @@
 import logging
 from dataclasses import replace
+from datetime import timedelta
 from time import time
 from typing import Any
 
@@ -9,9 +10,11 @@ from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_track_time_interval
 
 from .const import (
     BUTTONREPEAT_FIRST,
+    BUTTONREPEAT_LOOP,
     CONF_MODBUS_ADDR,
     DEFAULT_MODBUS_ADDR,
     DOMAIN,
@@ -23,6 +26,17 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+# The Gen3 X1 AC remote-control command expires on the inverter after 4 s with
+# no refresh (register 0x9F "export duration", left at its hardware default —
+# see plugin_solax.py:_compute_gen3_active_power). Rather than extending that
+# timer, refresh well inside the window via a dedicated timer independent of
+# any scan-group poll cadence — mirrors se-vpp-client/vpp-local's ControlLoop,
+# which refreshes its setpoint every 250 ms against the same 4 s expiry
+# (scaled down here since an HA integration doesn't need sub-second cadence
+# to stay comfortably inside a 4 s window).
+GEN3_RC_TRIGGER_KEY = "remotecontrol_trigger_gen3"
+GEN3_RC_KEEPALIVE_INTERVAL_S = 2
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> bool:
@@ -98,6 +112,7 @@ class SolaXModbusButton(ButtonEntity):
         self._command = button_info.command
         self._attr_icon = button_info.icon
         self._write_method = button_info.write_method
+        self._gen3_keepalive_unsub = None
 
     @property
     def name(self) -> str:
@@ -107,6 +122,45 @@ class SolaXModbusButton(ButtonEntity):
     @property
     def unique_id(self) -> str | None:
         return f"{self._platform_name}_{self._key}"
+
+    async def async_added_to_hass(self) -> None:
+        """Start the dedicated Gen3 RC keepalive timer, if this is that button."""
+        if self._key == GEN3_RC_TRIGGER_KEY:
+            self._gen3_keepalive_unsub = async_track_time_interval(
+                self.hass, self._async_gen3_rc_keepalive_tick, timedelta(seconds=GEN3_RC_KEEPALIVE_INTERVAL_S)
+            )
+
+    async def async_will_remove_from_hass(self) -> None:
+        if self._gen3_keepalive_unsub is not None:
+            self._gen3_keepalive_unsub()
+            self._gen3_keepalive_unsub = None
+
+    async def _async_gen3_rc_keepalive_tick(self, _now: Any = None) -> None:
+        """Refresh the Gen3 RC command every GEN3_RC_KEEPALIVE_INTERVAL_S, independent
+        of any scan-group poll cadence — see the module docstring above.
+
+        Only resends the *existing* session (does not renew its expiry, matching
+        the semantics of the scan-group-driven autorepeat loop in __init__.py);
+        a fresh async_press() is what extends _repeatUntil. No-ops silently
+        when there's no active RC session for this button to avoid racing the
+        expiry/cleanup handling already owned by that loop.
+        """
+        repeat_until = self._hub.data.get("_repeatUntil", {}).get(self._key, 0)
+        if repeat_until <= 0 or time() >= repeat_until:
+            return
+        if not self.button_info.value_function:
+            return
+        res = self.button_info.value_function(BUTTONREPEAT_LOOP, self.button_info, self._hub.data)
+        if not res:
+            return
+        action = res.get("action")
+        if action != WRITE_MULTI_MODBUS:
+            return
+        await self._hub.async_write_registers_multi(
+            unit=self._modbus_addr,
+            address=res.get("register", self._register),
+            payload=res.get("data"),
+        )
 
     async def async_press(self) -> None:
         """Write the button value."""

--- a/custom_components/solax_modbus/manifest.json
+++ b/custom_components/solax_modbus/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/wills106/homsassistant-solax-modbus/issues",
   "requirements": ["pymodbus>=3.8.3"],
-  "version": "2026.04.4"
+  "version": "2026.07.1"
 }

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -593,6 +593,36 @@ def autorepeat_function_remotecontrol_recompute(initval: int, descr: Any, datadi
     return {"action": WRITE_MULTI_MODBUS, "data": res}
 
 
+def _compute_gen3_active_power(datadict: dict[str, Any]) -> tuple[bool, int]:
+    """Clamp the requested Gen3 active-power target to the inverter's configured
+    hard import/export limits. Returns (enabled, ap_target_clamped).
+
+    Deliberately does *not* recompute the target from house_load/PV/phase-current
+    data the way the shared multi-mode `_compute_remotecontrol_ap_target` does
+    for modes 1-7. Gen3 X1 AC installations are commonly wired as a
+    secondary/retrofit battery on its own sub-circuit, where the inverter's own
+    grid/load/PV sensors do not represent the household's real power balance —
+    any "correction" derived from them is reacting to numbers unrelated to the
+    actual desired command. The caller (an external controller writing
+    remotecontrol_active_power) is expected to already provide a fully computed,
+    safety-checked setpoint; this only clamps it to the inverter's own
+    configured hard limits as a static last-resort safety floor — mirroring
+    se-vpp-client/vpp-local's inverter.py:_clamp_setpoint(), which clamps
+    against fixed configured values rather than a live sensor-derived bound.
+
+    Only "Enabled Power Control" is meaningful here — the mode-dispatch used by
+    modes 1-7 (Enabled Grid Control, Enabled Self Use, etc.) all depend on the
+    same house_load/PV assumption and are not supported for Gen3.
+    """
+    power_control = datadict.get("remotecontrol_power_control", "Disabled")
+    if power_control != "Enabled Power Control":
+        return False, 0
+    target = int(datadict.get("remotecontrol_active_power", 0))
+    import_limit = datadict.get("remotecontrol_import_limit", 20000)
+    export_limit = datadict.get("export_control_user_limit", 20000)
+    return True, int(max(-export_limit, min(import_limit, target)))
+
+
 def autorepeat_function_remotecontrol_recompute_gen3(initval: int, descr: Any, datadict: dict[str, Any]) -> dict[str, Any]:
     """Active power control for SolaX X1 AC G3 inverters.
 
@@ -602,10 +632,13 @@ def autorepeat_function_remotecontrol_recompute_gen3(initval: int, descr: Any, d
                          negative = export/discharge, positive = import/charge
       0x7F–0x80   S32  – reactive power (always 0)
 
-    The inverter reverts to self-consumption if no refresh arrives within
-    4 s. Set *remotecontrol_autorepeat_duration* to the desired
-    window (seconds) and the integration will keep sending commands every
-    poll cycle while the remote-control override is active.
+    The inverter reverts to self-consumption if no refresh arrives within 4 s
+    (register 0x9F "export duration" — left at its hardware default here; see
+    se-vpp-client/vpp-local/inverter.py, which deliberately leaves this at 4 s
+    rather than extending it, and instead refreshes the setpoint far more
+    often than the expiry window via a dedicated fast loop — see the
+    remotecontrol_trigger_gen3 button entity's keepalive timer in button.py,
+    which mirrors that design independent of the scan-group poll cadence).
     """
     if initval == BUTTONREPEAT_POST:
         # Zero all five registers to relinquish control
@@ -618,31 +651,31 @@ def autorepeat_function_remotecontrol_recompute_gen3(initval: int, descr: Any, d
             ],
         }
 
-    params = _compute_remotecontrol_ap_target(datadict)
-    power_control = params["power_control"]
-    ap_target = params["ap_target"]
-
-    # For Slave parallel mode, bail out silently
-    if power_control == "Disabled" and datadict.get("parallel_setting") == "Slave":
+    # For Slave parallel mode, bail out silently — orthogonal to the Gen3
+    # simplification above, this is a harness-level concern shared with the
+    # non-Gen3 remote-control path.
+    if datadict.get("parallel_setting") == "Slave":
         return {"action": WRITE_MULTI_MODBUS, "data": []}
 
-    res: list[tuple[Any, Any]] = [
-        (REGISTER_U16, 1),  # 0x7C: control enable
-        (REGISTER_S32, ap_target),  # 0x7D–0x7E: active power, LSW-first via order32=little
-        (REGISTER_S32, 0),  # 0x7F–0x80: reactive power (always 0 for Gen3)
-    ]
+    enabled, ap_target = _compute_gen3_active_power(datadict)
 
-    if power_control == "Disabled":
+    if not enabled:
         autorepeat_stop(datadict, "remotecontrol_trigger_gen3")
         # Emit disable frame immediately. autorepeat_stop() sets _repeatUntil to 0,
         # so no BUTTONREPEAT_POST cleanup frame will be sent by the scheduler.
-        res = [
+        res: list[tuple[Any, Any]] = [
             (REGISTER_U16, 0),
             (REGISTER_S32, 0),
             (REGISTER_S32, 0),
         ]
+    else:
+        res = [
+            (REGISTER_U16, 1),  # 0x7C: control enable
+            (REGISTER_S32, ap_target),  # 0x7D–0x7E: active power, LSW-first via order32=little
+            (REGISTER_S32, 0),  # 0x7F–0x80: reactive power (always 0 for Gen3)
+        ]
 
-    _LOGGER.debug(f"Evaluated remotecontrol_trigger_gen3: power_control={power_control} ap_target={ap_target}W payload: {res}")
+    _LOGGER.debug(f"Evaluated remotecontrol_trigger_gen3: enabled={enabled} ap_target={ap_target}W payload: {res}")
     return {"action": WRITE_MULTI_MODBUS, "data": res}
 
 

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -598,9 +598,9 @@ def autorepeat_function_remotecontrol_recompute_gen3(initval: int, descr: Any, d
         return {"action": WRITE_MULTI_MODBUS, "data": []}
 
     res: list[tuple[Any, Any]] = [
-        (REGISTER_U16, 1),         # 0x7C: control enable
+        (REGISTER_U16, 1),  # 0x7C: control enable
         (REGISTER_S32, ap_target),  # 0x7D–0x7E: active power, LSW-first via order32=little
-        (REGISTER_S32, 0),          # 0x7F–0x80: reactive power (always 0 for Gen3)
+        (REGISTER_S32, 0),  # 0x7F–0x80: reactive power (always 0 for Gen3)
     ]
 
     if power_control == "Disabled":

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -550,7 +550,7 @@ def autorepeat_function_remotecontrol_recompute(initval: int, descr: Any, datadi
         ("remotecontrol_set_type", params["set_type"]),
         ("remotecontrol_active_power", params["ap_target"]),
         ("remotecontrol_reactive_power", params["reactive_power"]),
-        ("remotecontrol_duration", datadict.get("remotecontrol_duration", 20)),
+        ("remotecontrol_duration", params["rc_duration"]),
         (REGISTER_U16, 0),  # dummy target soc
         (REGISTER_U32, 0),  # dummy target energy Wh
         (REGISTER_S32, 0),  # dummy target charge/discharge power

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -245,27 +245,20 @@ class SolaXModbusSwitchEntityDescription(BaseModbusSwitchEntityDescription):
 # ====================================== Computed value functions  =================================================
 
 
-def autorepeat_function_remotecontrol_recompute(initval: int, descr: Any, datadict: dict[str, Any]) -> dict[str, Any]:
-    """Remote control power calculations for SolaX inverters - Redesigned Implementation.
+def _compute_remotecontrol_ap_target(datadict: dict[str, Any]) -> dict[str, Any]:
+    """Shared computation of the clamped active-power target for remotecontrol modes 1-7.
 
-    This function implements the redesigned remote control calculations based on clear
-    variable names and logical formulas. For detailed documentation, see:
-    docs/solax-remote-control-redesigned.md
+    Reads control parameters, power measurements and phase data from *datadict*,
+    applies mode-specific logic, phase-envelope protection and import/export bounds,
+    and returns a dict with the final clamped values:
 
-    Args:
-        initval: BUTTONREPEAT_FIRST (first run), BUTTONREPEAT_LOOP (subsequent runs),
-                or BUTTONREPEAT_POST (cleanup)
-        descr: Entity description
-        datadict: Current sensor data dictionary
-
-    Returns:
-        Dictionary with action and data for Modbus write operations
+        power_control  – final mode string (may be normalised to "Enabled Power Control")
+        set_type       – "Set" or "Update"
+        ap_target      – clamped active power target in Watts (int)
+        reactive_power – clamped reactive power in VAr (int)
+        rc_duration    – command duration in seconds
+        rc_timeout     – autorepeat timeout in seconds
     """
-
-    # terminate expiring loop by disabling remotecontrol
-    if initval == BUTTONREPEAT_POST:
-        return {"action": WRITE_MULTI_MODBUS, "data": [("remotecontrol_power_control", "Disabled")]}
-
     # Get control parameters
     power_control = datadict.get("remotecontrol_power_control", "Disabled")
     set_type = datadict.get("remotecontrol_set_type", "Set")
@@ -300,7 +293,14 @@ def autorepeat_function_remotecontrol_recompute(initval: int, descr: Any, datadi
     elif parallel_setting == "Slave":
         # Slaves should not execute remote control
         _LOGGER.debug("[REMOTE_CONTROL] Parallel mode detected (Slave): skipping remote control")
-        return {"action": WRITE_MULTI_MODBUS, "data": []}
+        return {
+            "power_control": "Disabled",
+            "set_type": set_type,
+            "ap_target": 0,
+            "reactive_power": 0,
+            "rc_duration": rc_duration,
+            "rc_timeout": rc_timeout,
+        }
     else:
         # Single inverter mode - use individual values
         pv_power = datadict.get("pv_power_total", 0)
@@ -365,6 +365,9 @@ def autorepeat_function_remotecontrol_recompute(initval: int, descr: Any, datadi
             power_control = "Disabled"
 
     elif power_control == "Disabled":
+        ap_target = target
+
+    else:
         ap_target = target
 
     # Debug logging: Target calculation
@@ -504,23 +507,106 @@ def autorepeat_function_remotecontrol_recompute(initval: int, descr: Any, datadi
             f"adjusted_by={old_ap_target - ap_target}W"
         )
 
-    # Prepare result data
+    return {
+        "power_control": power_control,
+        "set_type": set_type,
+        "ap_target": int(ap_target),
+        "reactive_power": int(max(min(reap_up, reactive_power), reap_lo)),
+        "rc_duration": rc_duration,
+        "rc_timeout": rc_timeout,
+    }
+
+
+def autorepeat_function_remotecontrol_recompute(initval: int, descr: Any, datadict: dict[str, Any]) -> dict[str, Any]:
+    """Remote control power calculations for SolaX inverters - Redesigned Implementation.
+
+    This function implements the redesigned remote control calculations based on clear
+    variable names and logical formulas. For detailed documentation, see:
+    docs/solax-remote-control-redesigned.md
+
+    Args:
+        initval: BUTTONREPEAT_FIRST (first run), BUTTONREPEAT_LOOP (subsequent runs),
+                or BUTTONREPEAT_POST (cleanup)
+        descr: Entity description
+        datadict: Current sensor data dictionary
+
+    Returns:
+        Dictionary with action and data for Modbus write operations
+    """
+
+    # terminate expiring loop by disabling remotecontrol
+    if initval == BUTTONREPEAT_POST:
+        return {"action": WRITE_MULTI_MODBUS, "data": [("remotecontrol_power_control", "Disabled")]}
+
+    params = _compute_remotecontrol_ap_target(datadict)
+    power_control = params["power_control"]
+
+    # For Slave parallel mode, _compute returns Disabled with empty ap_target — bail out silently
+    if power_control == "Disabled" and datadict.get("parallel_setting") == "Slave":
+        return {"action": WRITE_MULTI_MODBUS, "data": []}
+
     res = [
         ("remotecontrol_power_control", power_control),
-        ("remotecontrol_set_type", set_type),
-        ("remotecontrol_active_power", ap_target),
-        ("remotecontrol_reactive_power", max(min(reap_up, reactive_power), reap_lo)),
-        ("remotecontrol_duration", rc_duration),
+        ("remotecontrol_set_type", params["set_type"]),
+        ("remotecontrol_active_power", params["ap_target"]),
+        ("remotecontrol_reactive_power", params["reactive_power"]),
+        ("remotecontrol_duration", datadict.get("remotecontrol_duration", 20)),
         (REGISTER_U16, 0),  # dummy target soc
         (REGISTER_U32, 0),  # dummy target energy Wh
         (REGISTER_S32, 0),  # dummy target charge/discharge power
-        ("remotecontrol_timeout", rc_timeout),
+        ("remotecontrol_timeout", params["rc_timeout"]),
     ]
 
     if power_control == "Disabled":
         autorepeat_stop(datadict, "remotecontrol_trigger")
 
     _LOGGER.debug(f"Evaluated remotecontrol_trigger: corrected/clamped values: {res}")
+    return {"action": WRITE_MULTI_MODBUS, "data": res}
+
+
+def autorepeat_function_remotecontrol_recompute_gen3(initval: int, descr: Any, datadict: dict[str, Any]) -> dict[str, Any]:
+    """Active power control for SolaX X1 AC G3 inverters.
+
+    Sends a 5-register FC16 burst starting at 0x7C:
+      0x7C        U16  – control enable (1 = active, 0 = disabled)
+      0x7D–0x7E   S32  – active power in Watts, LSW-first (order32=little)
+                         negative = export/discharge, positive = import/charge
+      0x7F–0x80   S32  – reactive power (always 0)
+
+    The inverter reverts to self-consumption if no refresh arrives within 4 s
+    (configured via register 0x9F = 4 at startup).  Set
+    *remotecontrol_autorepeat_duration* to the desired window (seconds) and
+    the integration will keep sending commands every poll cycle.
+    """
+    if initval == BUTTONREPEAT_POST:
+        # Zero all five registers to relinquish control
+        return {
+            "action": WRITE_MULTI_MODBUS,
+            "data": [
+                (REGISTER_U16, 0),  # 0x7C: disable control
+                (REGISTER_S32, 0),  # 0x7D–0x7E: active power = 0
+                (REGISTER_S32, 0),  # 0x7F–0x80: reactive power = 0
+            ],
+        }
+
+    params = _compute_remotecontrol_ap_target(datadict)
+    power_control = params["power_control"]
+    ap_target = params["ap_target"]
+
+    # For Slave parallel mode, bail out silently
+    if power_control == "Disabled" and datadict.get("parallel_setting") == "Slave":
+        return {"action": WRITE_MULTI_MODBUS, "data": []}
+
+    res: list[tuple[Any, Any]] = [
+        (REGISTER_U16, 1),         # 0x7C: control enable
+        (REGISTER_S32, ap_target),  # 0x7D–0x7E: active power, LSW-first via order32=little
+        (REGISTER_S32, 0),          # 0x7F–0x80: reactive power (always 0 for Gen3)
+    ]
+
+    if power_control == "Disabled":
+        autorepeat_stop(datadict, "remotecontrol_trigger_gen3")
+
+    _LOGGER.debug(f"Evaluated remotecontrol_trigger_gen3: power_control={power_control} ap_target={ap_target}W payload: {res}")
     return {"action": WRITE_MULTI_MODBUS, "data": res}
 
 
@@ -1158,6 +1244,16 @@ BUTTON_TYPES: Sequence["SolaxModbusButtonEntityDescription"] = [
         autorepeat="remotecontrol_autorepeat_duration",
     ),
     SolaxModbusButtonEntityDescription(
+        name="Remotecontrol Trigger Gen3 (mode 1-7)",
+        key="remotecontrol_trigger_gen3",
+        register=0x7C,
+        allowedtypes=AC | GEN3 | X1,
+        write_method=WRITE_MULTI_MODBUS,
+        icon="mdi:battery-clock",
+        value_function=autorepeat_function_remotecontrol_recompute_gen3,
+        autorepeat="remotecontrol_autorepeat_duration",
+    ),
+    SolaxModbusButtonEntityDescription(
         name="PowerControlMode Trigger (mode 8/9)",
         key="powercontrolmode8_trigger",
         register=0xA0,
@@ -1418,7 +1514,7 @@ NUMBER_TYPES: Sequence["SolaxModbusNumberEntityDescription"] = [
     SolaxModbusNumberEntityDescription(
         name="Remotecontrol Active Power (mode 1)",
         key="remotecontrol_active_power",
-        allowedtypes=AC | HYBRID | GEN4 | GEN5,
+        allowedtypes=AC | HYBRID | GEN3 | GEN4 | GEN5,
         native_min_value=-30000,
         native_max_value=30000,
         native_step=100,
@@ -1465,7 +1561,7 @@ NUMBER_TYPES: Sequence["SolaxModbusNumberEntityDescription"] = [
         name="Remotecontrol Autorepeat Duration (mode 1-9)",
         key="remotecontrol_autorepeat_duration",
         register_data_type=REGISTER_U16,
-        allowedtypes=AC | HYBRID | GEN4 | GEN5 | GEN6,
+        allowedtypes=AC | HYBRID | GEN3 | GEN4 | GEN5 | GEN6,
         icon="mdi:home-clock",
         initvalue=0,  # seconds -
         native_min_value=0,
@@ -1479,7 +1575,7 @@ NUMBER_TYPES: Sequence["SolaxModbusNumberEntityDescription"] = [
     SolaxModbusNumberEntityDescription(
         name="Remotecontrol Import Limit (mode 1-9)",
         key="remotecontrol_import_limit",
-        allowedtypes=AC | HYBRID | GEN4 | GEN5 | GEN6,
+        allowedtypes=AC | HYBRID | GEN3 | GEN4 | GEN5 | GEN6,
         native_min_value=0,
         native_max_value=30000,  # overwritten by MAX_EXPORT
         native_step=100,
@@ -1552,7 +1648,7 @@ NUMBER_TYPES: Sequence["SolaxModbusNumberEntityDescription"] = [
     SolaxModbusNumberEntityDescription(
         name="Remotecontrol Timeout (mode 1-9)",
         key="remotecontrol_timeout",
-        allowedtypes=AC | HYBRID | GEN4 | GEN5 | GEN6,
+        allowedtypes=AC | HYBRID | GEN3 | GEN4 | GEN5 | GEN6,
         native_min_value=0,
         native_max_value=28800,
         native_step=1,
@@ -2508,7 +2604,7 @@ SELECT_TYPES: Sequence["SolaxModbusSelectEntityDescription"] = [
             # 2: "Enabled Quantity Control",
             # 3: "Enabled SOC Target Control",
         },
-        allowedtypes=AC | HYBRID | GEN4 | GEN5,
+        allowedtypes=AC | HYBRID | GEN3 | GEN4 | GEN5,
         initvalue=0,  # Disabled
         icon="mdi:transmission-tower",
     ),

--- a/custom_components/solax_modbus/plugin_solax.py
+++ b/custom_components/solax_modbus/plugin_solax.py
@@ -573,10 +573,10 @@ def autorepeat_function_remotecontrol_recompute_gen3(initval: int, descr: Any, d
                          negative = export/discharge, positive = import/charge
       0x7F–0x80   S32  – reactive power (always 0)
 
-    The inverter reverts to self-consumption if no refresh arrives within 4 s
-    (configured via register 0x9F = 4 at startup).  Set
-    *remotecontrol_autorepeat_duration* to the desired window (seconds) and
-    the integration will keep sending commands every poll cycle.
+    The inverter reverts to self-consumption if no refresh arrives within
+    4 s. Set *remotecontrol_autorepeat_duration* to the desired
+    window (seconds) and the integration will keep sending commands every
+    poll cycle while the remote-control override is active.
     """
     if initval == BUTTONREPEAT_POST:
         # Zero all five registers to relinquish control
@@ -605,6 +605,13 @@ def autorepeat_function_remotecontrol_recompute_gen3(initval: int, descr: Any, d
 
     if power_control == "Disabled":
         autorepeat_stop(datadict, "remotecontrol_trigger_gen3")
+        # Emit disable frame immediately. autorepeat_stop() sets _repeatUntil to 0,
+        # so no BUTTONREPEAT_POST cleanup frame will be sent by the scheduler.
+        res = [
+            (REGISTER_U16, 0),
+            (REGISTER_S32, 0),
+            (REGISTER_S32, 0),
+        ]
 
     _LOGGER.debug(f"Evaluated remotecontrol_trigger_gen3: power_control={power_control} ap_target={ap_target}W payload: {res}")
     return {"action": WRITE_MULTI_MODBUS, "data": res}

--- a/tests/unit/test_plugin_logic.py
+++ b/tests/unit/test_plugin_logic.py
@@ -4,11 +4,17 @@ import pytest
 
 from custom_components.solax_modbus.plugin_solax import (
     AC,
+    BUTTONREPEAT_FIRST,
+    BUTTONREPEAT_POST,
     EPS,
     GEN3,
     GEN4,
     HYBRID,
+    REGISTER_S32,
+    REGISTER_U16,
+    WRITE_MULTI_MODBUS,
     X3,
+    autorepeat_function_remotecontrol_recompute_gen3,
 )
 from custom_components.solax_modbus.plugin_solax import (
     plugin_instance as solax_plugin,
@@ -148,3 +154,59 @@ def test_parallel_master_scales_import_limit(mock_hub: Any) -> None:
     assert entity._attr_native_max_value == 45000, (
         f"Parallel Master with 45kW capacity should scale import limit to 45000W, got {entity._attr_native_max_value}W"
     )
+
+
+def test_remotecontrol_gen3_payload_shape_enabled() -> None:
+    datadict = {
+        "remotecontrol_power_control": "Enabled Power Control",
+        "remotecontrol_active_power": -1000,
+        "remotecontrol_reactive_power": 0,
+        "remotecontrol_duration": 20,
+        "remotecontrol_timeout": 0,
+        "remotecontrol_import_limit": 20000,
+        "export_control_user_limit": 20000,
+    }
+
+    payload = autorepeat_function_remotecontrol_recompute_gen3(BUTTONREPEAT_FIRST, None, datadict)
+
+    assert payload["action"] == WRITE_MULTI_MODBUS
+    assert payload["data"] == [
+        (REGISTER_U16, 1),
+        (REGISTER_S32, -1000),
+        (REGISTER_S32, 0),
+    ]
+
+
+def test_remotecontrol_gen3_payload_shape_post_cleanup() -> None:
+    payload = autorepeat_function_remotecontrol_recompute_gen3(BUTTONREPEAT_POST, None, {})
+
+    assert payload["action"] == WRITE_MULTI_MODBUS
+    assert payload["data"] == [
+        (REGISTER_U16, 0),
+        (REGISTER_S32, 0),
+        (REGISTER_S32, 0),
+    ]
+
+
+def test_remotecontrol_gen3_disabled_calls_autorepeat_stop(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[dict[str, Any], str]] = []
+
+    def fake_autorepeat_stop(data: dict[str, Any], key: str) -> None:
+        calls.append((data, key))
+
+    monkeypatch.setattr("custom_components.solax_modbus.plugin_solax.autorepeat_stop", fake_autorepeat_stop)
+
+    datadict: dict[str, Any] = {
+        "remotecontrol_power_control": "Disabled",
+        "remotecontrol_active_power": 0,
+    }
+
+    payload = autorepeat_function_remotecontrol_recompute_gen3(BUTTONREPEAT_FIRST, None, datadict)
+
+    assert payload["action"] == WRITE_MULTI_MODBUS
+    assert payload["data"] == [
+        (REGISTER_U16, 0),
+        (REGISTER_S32, 0),
+        (REGISTER_S32, 0),
+    ]
+    assert calls == [(datadict, "remotecontrol_trigger_gen3")]

--- a/tests/unit/test_plugin_logic.py
+++ b/tests/unit/test_plugin_logic.py
@@ -212,3 +212,77 @@ def test_remotecontrol_gen3_disabled_calls_autorepeat_stop(monkeypatch: pytest.M
         (REGISTER_S32, 0),
     ]
     assert calls == [(datadict, "remotecontrol_trigger_gen3")]
+
+
+def test_remotecontrol_gen3_clamps_to_import_limit() -> None:
+    """Gen3 clamps to the configured hard import_limit, not a house_load-derived bound."""
+    datadict = {
+        "remotecontrol_power_control": "Enabled Power Control",
+        "remotecontrol_active_power": 5000,
+        "remotecontrol_import_limit": 2000,
+        "export_control_user_limit": 20000,
+        # house_load/pv_power/measured_power deliberately absent: Gen3 must not
+        # depend on them at all.
+    }
+
+    payload = autorepeat_function_remotecontrol_recompute_gen3(BUTTONREPEAT_FIRST, None, datadict)
+
+    assert payload["data"] == [
+        (REGISTER_U16, 1),
+        (REGISTER_S32, 2000),
+        (REGISTER_S32, 0),
+    ]
+
+
+def test_remotecontrol_gen3_clamps_to_export_limit() -> None:
+    datadict = {
+        "remotecontrol_power_control": "Enabled Power Control",
+        "remotecontrol_active_power": -5000,
+        "remotecontrol_import_limit": 20000,
+        "export_control_user_limit": 2000,
+    }
+
+    payload = autorepeat_function_remotecontrol_recompute_gen3(BUTTONREPEAT_FIRST, None, datadict)
+
+    assert payload["data"] == [
+        (REGISTER_U16, 1),
+        (REGISTER_S32, -2000),
+        (REGISTER_S32, 0),
+    ]
+
+
+def test_remotecontrol_gen3_ignores_other_modes() -> None:
+    """Only "Enabled Power Control" is meaningful for Gen3 — the mode-dispatch used
+    by the shared modes 1-7 path (Enabled Self Use, Enabled Grid Control, etc.) all
+    depend on house_load/PV assumptions that don't hold for a Gen3 retrofit battery
+    wired to its own sub-circuit, so Gen3 must not fall into them."""
+    datadict: dict[str, Any] = {
+        "remotecontrol_power_control": "Enabled Self Use",
+        "remotecontrol_active_power": -1000,
+        "remotecontrol_import_limit": 20000,
+        "export_control_user_limit": 20000,
+        "house_load": 500,  # if this were honoured, Enabled Self Use would target -500W
+        "_repeatUntil": {},
+    }
+
+    payload = autorepeat_function_remotecontrol_recompute_gen3(BUTTONREPEAT_FIRST, None, datadict)
+
+    assert payload["data"] == [
+        (REGISTER_U16, 0),
+        (REGISTER_S32, 0),
+        (REGISTER_S32, 0),
+    ]
+
+
+def test_remotecontrol_gen3_parallel_slave_bails_out_silently() -> None:
+    datadict = {
+        "remotecontrol_power_control": "Enabled Power Control",
+        "remotecontrol_active_power": -1000,
+        "remotecontrol_import_limit": 20000,
+        "export_control_user_limit": 20000,
+        "parallel_setting": "Slave",
+    }
+
+    payload = autorepeat_function_remotecontrol_recompute_gen3(BUTTONREPEAT_FIRST, None, datadict)
+
+    assert payload == {"action": WRITE_MULTI_MODBUS, "data": []}

--- a/tests/unit/test_plugin_logic.py
+++ b/tests/unit/test_plugin_logic.py
@@ -2,17 +2,19 @@ from typing import Any
 
 import pytest
 
-from custom_components.solax_modbus.plugin_solax import (
-    AC,
+from custom_components.solax_modbus.const import (
     BUTTONREPEAT_FIRST,
     BUTTONREPEAT_POST,
+    REGISTER_S32,
+    REGISTER_U16,
+    WRITE_MULTI_MODBUS,
+)
+from custom_components.solax_modbus.plugin_solax import (
+    AC,
     EPS,
     GEN3,
     GEN4,
     HYBRID,
-    REGISTER_S32,
-    REGISTER_U16,
-    WRITE_MULTI_MODBUS,
     X3,
     autorepeat_function_remotecontrol_recompute_gen3,
 )

--- a/tests/unit/test_write_registers_multi_atomicity.py
+++ b/tests/unit/test_write_registers_multi_atomicity.py
@@ -8,7 +8,7 @@ middle shifts everything after them to the wrong address on the wire.
 """
 
 import asyncio
-from typing import Any
+from typing import Any, cast
 from unittest.mock import AsyncMock
 
 import pytest
@@ -45,7 +45,7 @@ async def test_write_registers_multi_writes_when_all_tuples_encode_cleanly() -> 
     hub = _FakeHub()
 
     resp = await SolaXModbusHub.async_write_registers_multi(
-        hub,
+        cast(SolaXModbusHub, hub),
         unit=1,
         address=0x7C,
         payload=[
@@ -67,7 +67,7 @@ async def test_write_registers_multi_aborts_on_cast_failure_instead_of_truncatin
     hub = _FakeHub()
 
     resp = await SolaXModbusHub.async_write_registers_multi(
-        hub,
+        cast(SolaXModbusHub, hub),
         unit=1,
         address=0x7C,
         payload=[
@@ -86,7 +86,7 @@ async def test_write_registers_multi_aborts_on_encoding_failure_instead_of_trunc
     hub = _FakeHub()
 
     resp = await SolaXModbusHub.async_write_registers_multi(
-        hub,
+        cast(SolaXModbusHub, hub),
         unit=1,
         address=0x7C,
         payload=[

--- a/tests/unit/test_write_registers_multi_atomicity.py
+++ b/tests/unit/test_write_registers_multi_atomicity.py
@@ -1,0 +1,100 @@
+"""Regression tests: async_write_registers_multi must be atomic.
+
+A single tuple's encoding failure must abort the whole write rather than
+silently sending a shorter, misaligned register list — a burst like the
+Gen3 remote-control command (enable flag + active power + reactive power)
+is meant to land as one consecutive block, and dropping registers from the
+middle shifts everything after them to the wrong address on the wire.
+"""
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.solax_modbus import SolaXModbusHub
+from custom_components.solax_modbus.const import REGISTER_S32, REGISTER_U16
+
+
+class _FakePlugin:
+    order32 = "big"
+
+
+class _FakeHub:
+    """Minimal duck-typed stand-in for the attributes async_write_registers_multi touches."""
+
+    def __init__(self) -> None:
+        self._name = "test"
+        self.plugin = _FakePlugin()
+        self.writeLocals: dict[str, Any] = {}
+        self._lock = asyncio.Lock()
+        self.slowdown = 1
+        self._client = AsyncMock()
+        self._client.write_registers = AsyncMock(return_value="ok")
+
+    async def is_online(self) -> bool:
+        return True
+
+    async def _track_task(self, coro: Any) -> Any:
+        return await coro
+
+
+@pytest.mark.asyncio
+async def test_write_registers_multi_writes_when_all_tuples_encode_cleanly() -> None:
+    hub = _FakeHub()
+
+    resp = await SolaXModbusHub.async_write_registers_multi(
+        hub,
+        unit=1,
+        address=0x7C,
+        payload=[
+            (REGISTER_U16, 1),
+            (REGISTER_S32, -1000),
+            (REGISTER_S32, 0),
+        ],
+    )
+
+    assert resp == "ok"
+    hub._client.write_registers.assert_awaited_once()
+    _, kwargs = hub._client.write_registers.call_args
+    # 1 register for U16 + 2 + 2 for the two S32 values = 5 registers, not fewer.
+    assert len(kwargs["values"]) == 5
+
+
+@pytest.mark.asyncio
+async def test_write_registers_multi_aborts_on_cast_failure_instead_of_truncating() -> None:
+    hub = _FakeHub()
+
+    resp = await SolaXModbusHub.async_write_registers_multi(
+        hub,
+        unit=1,
+        address=0x7C,
+        payload=[
+            (REGISTER_U16, 1),
+            (REGISTER_S32, "not-a-number"),  # fails int() cast
+            (REGISTER_S32, 0),
+        ],
+    )
+
+    assert resp is None
+    hub._client.write_registers.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_write_registers_multi_aborts_on_encoding_failure_instead_of_truncating() -> None:
+    hub = _FakeHub()
+
+    resp = await SolaXModbusHub.async_write_registers_multi(
+        hub,
+        unit=1,
+        address=0x7C,
+        payload=[
+            (REGISTER_U16, 1),
+            (REGISTER_S32, 2**40),  # out of int32 range: struct.error inside convert_to_registers
+            (REGISTER_S32, 0),
+        ],
+    )
+
+    assert resp is None
+    hub._client.write_registers.assert_not_awaited()


### PR DESCRIPTION
## Summary
- Rewrites the Gen3 X1 AC remote-control write path as a dumb pipe (`_compute_gen3_active_power`): clamps the externally-supplied setpoint to the inverter's configured hard import/export limits only, rather than recomputing it from house_load/PV/phase-current data that doesn't represent a secondary/retrofit battery's real power balance. Only "Enabled Power Control" is dispatched for Gen3 now.
- Adds a dedicated 2s keepalive timer to the `remotecontrol_trigger_gen3` button, refreshing the active RC session independent of scan-group poll cadence (mirrors se-vpp-client/vpp-local's control loop design).
- Makes `async_write_registers_multi` atomic on encoding failure: a single tuple failing to encode now aborts the whole write instead of silently sending a shorter, misaligned register burst.
- Bumps manifest version to 2026.07.1.

## Note on scope
This branch is cherry-picked from `retrofit-activepower-rebased` (which was rebased onto upstream `main` and has diverged significantly from this fork's `main`) rather than opened directly, to avoid a ~262-commit diff full of hash-duplicated history that's already merged into this fork's `main` via PR #8. Only the genuinely new commits since that rebase are included here, plus two small fixes for pre-existing strict-mypy failures on the source branch (a missing type annotation on the keepalive unsub handle, and a test-double cast) that would otherwise have blocked CI.

See `docs/gen3-remotecontrol-drop-investigation.md` (PR #10) for the investigation into a periodic Gen3 power drop that was initially suspected to be caused by this rewrite — it turned out to be unrelated external Modbus bus contention from another device, not a bug in this code.

## Test plan
- [x] `mypy custom_components/solax_modbus tests --strict` — clean
- [x] `pytest -m "not slow"` — 341 passed (1 pre-existing, unrelated `hass`-fixture collection error confirmed to already exist on unmodified `main`)
- [x] `ruff check` / `ruff format --check` — clean

https://claude.ai/code/session_016j33bVrt12efxBrkZGfZHe